### PR TITLE
tyk.conf: disable CP by default

### DIFF
--- a/tyk/tyk.conf
+++ b/tyk/tyk.conf
@@ -96,7 +96,7 @@
     "enable_custom_domains": true,
     "enable_jsvm": true,
     "coprocess_options": {
-        "enable_coprocess": true
+        "enable_coprocess": false
     },
     "hide_generator_header": false,
     "event_handlers": {


### PR DESCRIPTION
As a workaround for [this](https://community.tyk.io/t/no-grpc-url-is-set/1661).